### PR TITLE
update manifest to v3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Knockoutjs context debugger",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "Shows the knockout context & data for the selected dom node in a sidebar of the elements pane.",
   "icons": {
     "48": "icons/logo-48.png",

--- a/manifest.json
+++ b/manifest.json
@@ -11,11 +11,9 @@
     "tabs"
   ],
   "background": {
-    "scripts": [
-      "background.js"
-    ]
+    "service_worker": "background.js"
   },
-  "manifest_version": 2,
+  "manifest_version": 3,
   "options_ui": {
     "page": "pages/options.html",
     "open_in_tab": true


### PR DESCRIPTION
resolves #44
tested with chrome and edge, worked
tested with FF standaard not supported, expected end of 2022
tested with FF developer preview 103 worked partial, service work not yet supported [blog comment](https://blog.mozilla.org/addons/2022/05/18/manifest-v3-in-firefox-recap-next-steps/#comment-227483) fallback to background.scripts worked.

As far as possible now tested, this might resolve #42 and resolve #43 also see [issuecomment](https://github.com/timstuyckens/chromeextensions-knockoutjs/issues/42#issuecomment-1170471735)